### PR TITLE
Reference/Create New Project by Name Rather than ID

### DIFF
--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -46,7 +46,7 @@ module "multiarch-k8s" {
   # version = "0.5.0" # Use the latest version, according to https://github.com/equinix/terraform-metal-multiarch-k8s/releases
 
   auth_token   = var.auth_token
-  project_id   = var.project_id
+  project_id   = var.metal_create_project ? equinix_metal_project.new_project[0].id : data.equinix_metal_project.project.project_id
   metro        = var.metro
   count_arm    = var.count_arm
   count_x86    = var.count_x86

--- a/kubernetes-controller-pool.tf
+++ b/kubernetes-controller-pool.tf
@@ -29,7 +29,7 @@ resource "equinix_metal_ssh_key" "kubernetes-on-metal" {
 }
 
 resource "equinix_metal_reserved_ip_block" "kubernetes" {
-  project_id = var.metal_create_project ? equinix_metal_project.new_project[0].id : var.project_id
+  project_id = var.metal_create_project ? equinix_metal_project.new_project[0].id : data.equinix_metal_project.project.project_id
   metro      = var.metro != "" ? var.metro : null
   quantity   = 4
 }
@@ -45,7 +45,7 @@ module "controllers" {
   metro                    = var.metro
   cluster_name             = var.cluster_name
   kubernetes_lb_block      = equinix_metal_reserved_ip_block.kubernetes.cidr_notation
-  project_id               = var.metal_create_project ? equinix_metal_project.new_project[0].id : var.project_id
+  project_id               = var.metal_create_project ? equinix_metal_project.new_project[0].id : data.equinix_metal_project.project.project_id
   auth_token               = var.auth_token
   secrets_encryption       = var.secrets_encryption
   configure_ingress        = var.configure_ingress

--- a/kubernetes-node-pool.tf
+++ b/kubernetes-node-pool.tf
@@ -11,7 +11,7 @@ module "node_pool_blue" {
   metro              = var.metro
   cluster_name       = var.cluster_name
   controller_address = module.controllers.controller_addresses
-  project_id         = var.metal_create_project ? equinix_metal_project.new_project[0].id : var.project_id
+  project_id         = var.metal_create_project ? equinix_metal_project.new_project[0].id : data.equinix_metal_project.project.project_id
   storage            = var.storage
   ccm_enabled        = var.ccm_enabled
 
@@ -28,7 +28,7 @@ module "node_pool_gpu_green" {
   metro              = var.metro
   cluster_name       = var.cluster_name
   controller_address = module.controllers.controller_addresses
-  project_id         = var.metal_create_project ? equinix_metal_project.new_project[0].id : var.project_id
+  project_id         = var.metal_create_project ? equinix_metal_project.new_project[0].id : data.equinix_metal_project.project.project_id
   storage            = var.storage
   ccm_enabled        = var.ccm_enabled
 }

--- a/main.tf
+++ b/main.tf
@@ -9,3 +9,7 @@ resource "equinix_metal_project" "new_project" {
     asn             = 65000
   }
 }
+
+data "equinix_metal_project" "project" {
+  name = var.metal_create_project ? equinix_metal_project.new_project[0].name : var.project_name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -11,10 +11,10 @@ variable "metro" {
   default     = "dc"
 }
 
-variable "project_id" {
+variable "project_name" {
   type        = string
   default     = "null"
-  description = "Equinix Metal Project ID"
+  description = "Equinix Metal Project name"
 }
 
 variable "metal_create_project" {


### PR DESCRIPTION
Convenience update: rather than needing the ID, user can specify (or define for creation) a project by its name rather than ID (and then ID is rendered via datasource). Changes variable from project_id to project_name and updates module accordingly. 